### PR TITLE
fix: DataTable cells vertical alignment

### DIFF
--- a/RG_CHANGELOG.rst
+++ b/RG_CHANGELOG.rst
@@ -1,0 +1,14 @@
+RG Changelog
+############
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
+and this project adheres to customized Semantic Versioning e.g.: `redwood-rg.1`
+
+[Unreleased]
+************
+
+Fixes
+=====
+* Fix DataTable cells vertical alignment (RGOeX-26438)

--- a/src/order-history/OrderHistoryPage.jsx
+++ b/src/order-history/OrderHistoryPage.jsx
@@ -77,7 +77,7 @@ class OrderHistoryPage extends React.Component {
       description,
       quantity,
     }) => (
-      <p className="d-flex" key={description}>
+      <p className="d-flex m-0" key={description}>
         <span className="mr-3">{quantity}&times;</span>
         <span>{description}</span>
       </p>


### PR DESCRIPTION
## Description

Our proposal is to remove the bottom margin from the

element in the first column of the table. This margin is causing the center alignment within the cell to break in our table. Attached below is a screenshot of the problem and a screenshot after the fix.

<img width="1796" alt="312053626-a223169a-7393-4bae-8357-4c5b7ab2254b" src="https://github.com/user-attachments/assets/254b340f-c331-42be-8b39-25670d11b989" />

After fix

<img width="1796" alt="312053648-dd85b6d7-8028-4152-9cad-ce92ade4b59e" src="https://github.com/user-attachments/assets/a1f0fc62-e92f-4cc4-a46e-f92f3dd5c10c" />
